### PR TITLE
Enable usage in Firefox

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,7 @@
   "content_scripts": [
     {
       "matches": [
-        "https://github.com/notifications/*",
+        "https://github.com/notifications*",
         "https://github.com/*/notifications",
         "https://github.com/notifications?all=*"
       ],

--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -1,22 +1,20 @@
-chrome.extension.sendMessage({}, function (response) {
-  var readyStateCheckInterval = setInterval(function () {
-    if (document.readyState === "complete") {
-      clearInterval(readyStateCheckInterval);
+var readyStateCheckInterval = setInterval(function () {
+  if (document.readyState === "complete") {
+    clearInterval(readyStateCheckInterval);
 
-      console.log("Hello. This message was sent from scripts/inject.js");
-      d3.select('.notification-center .tabnav .float-right')
-        .insert('a',':first-child')
-        .text('Open all')
-        .attr('class','btn btn-sm')
-        .on("click", function() {
-          d3.selectAll('.notifications-list .list-group-item.unread')
-            .classed('unread',false)
-            .classed('read',true)
-            .selectAll('a.list-group-item-link')
-            .each(function() {
-              window.open(this.href);
-            })
-        });
-    }
-  }, 10);
-});
+    console.log("Hello. This message was sent from scripts/inject.js");
+    d3.select('.notification-center .tabnav .float-right')
+      .insert('a',':first-child')
+      .text('Open all')
+      .attr('class','btn btn-sm')
+      .on("click", function() {
+        d3.selectAll('.notifications-list .list-group-item.unread')
+          .classed('unread',false)
+          .classed('read',true)
+          .selectAll('a.list-group-item-link')
+          .each(function() {
+            window.open(this.href);
+          })
+      });
+  }
+}, 10);


### PR DESCRIPTION
Fixing one of the `matches` and removing an (now) unnecessary wrapping in `chrome.extension.sendMessage` makes this extension usable in Firefox as well.