### PR TITLE
Support new notifications page

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -17,8 +17,8 @@
     {
       "matches": [
         "https://github.com/notifications/*",
-        "https://github.com/*/notifications",
-        "https://github.com/notifications?all=*"
+        "https://github.com/*/notifications*",
+        "https://github.com/notifications*"
       ],
       "js": [
         "lib/d3.v4.min.js",

--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -4,15 +4,15 @@ chrome.extension.sendMessage({}, function (response) {
       clearInterval(readyStateCheckInterval);
 
       console.log("Hello. This message was sent from scripts/inject.js");
-      d3.select('.notification-center .tabnav .float-right')
+      d3.select('.notifications-list .Box-header')
         .insert('a',':first-child')
         .text('Open all')
         .attr('class','btn btn-sm')
         .on("click", function() {
-          d3.selectAll('.notifications-list .list-group-item.unread')
-            .classed('unread',false)
-            .classed('read',true)
-            .selectAll('a.list-group-item-link')
+          d3.selectAll('.notification-unread')
+            .classed('notification-unread',false)
+            .classed('notification-read',true)
+            .selectAll('a.notification-list-item-link')
             .each(function() {
               window.open(this.href);
             })


### PR DESCRIPTION
I fixed CSS selectors to support the new [notofications page](https://github.blog/2020-04-22-improving-notifications-for-everyone/).

![スクリーンショット 2020-04-24 16 56 26](https://user-images.githubusercontent.com/18360/80188759-998ccf00-864c-11ea-9b38-24e2af8a35b8.png)

